### PR TITLE
[Cargo.toml] Add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokio-cadence"
 description = "Tokio-based metric sinks for Cadence "
 version = "0.1.0"
+repository = "https://github.com/ecliptical/tokio-cadence"
 authors = ["Peter Nehrer <pnehrer@eclipticalsoftware.com>"]
 license = "MIT"
 keywords = ["cadence", "statsd", "metrics", "async", "tokio"]


### PR DESCRIPTION
Currently your [crates link](https://crates.io/crates/tokio-cadence) looks like this:
<img width="1012" alt="Screen Shot 2020-10-29 at 6 11 55 pm" src="https://user-images.githubusercontent.com/807580/97537037-3ec89b80-1a12-11eb-894a-e5e3d78e45c5.png">

Whereas it could look like this:
<img width="1037" alt="Screen Shot 2020-10-29 at 6 12 25 pm" src="https://user-images.githubusercontent.com/807580/97537095-54d65c00-1a12-11eb-86d5-adafe095b96f.png">
