### PR TITLE
Update tokio to 1.1, also run cargo fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ keywords = ["cadence", "statsd", "metrics", "async", "tokio"]
 edition = "2018"
 
 [dependencies]
-cadence = "0.22"
+cadence = "0.24"
 log = "0.4"
-tokio = { version = "0.2", features = ["net", "sync", "time"] }
+tokio = { version = "1.1", features = ["net", "sync", "time"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"
 
 [dev-dependencies.tokio]
-version = "0.2"
-features = ["net", "sync", "time", "macros", "rt-threaded"]
+version = "1.1"
+features = ["net", "sync", "time", "macros", "rt-multi-thread"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,11 +2,7 @@
 
 use tokio::time::Duration;
 
-use crate::{
-    DEFAULT_BATCH_BUF_SIZE,
-    DEFAULT_MAX_BATCH_DELAY,
-    DEFAULT_QUEUE_CAPACITY,
-};
+use crate::{DEFAULT_BATCH_BUF_SIZE, DEFAULT_MAX_BATCH_DELAY, DEFAULT_QUEUE_CAPACITY};
 
 /// Builder allows you to override various default parameter values before creating an instance
 /// of the desired Metric Sink.

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,43 +1,26 @@
 //! Asynchronous Metric Sink implementation that uses UDP sockets.
 
-use cadence::{
-    ErrorKind as MetricErrorKind,
-    MetricError,
-    MetricResult,
-    MetricSink,
-};
+use cadence::{ErrorKind as MetricErrorKind, MetricError, MetricResult, MetricSink};
 
 use log::*;
 use std::{
     future::Future,
     io::Result,
-    net::{
-        SocketAddr,
-        ToSocketAddrs,
-    },
-    panic::{
-        RefUnwindSafe,
-        UnwindSafe,
-    },
+    net::{SocketAddr, ToSocketAddrs},
+    panic::{RefUnwindSafe, UnwindSafe},
     pin::Pin,
 };
 
 use tokio::{
     net::UdpSocket,
-    sync::mpsc::{
-        channel,
-        Sender,
-    },
+    sync::mpsc::{channel, Sender},
     time::Duration,
 };
 
 use crate::{
     builder::Builder,
     define_worker,
-    worker::{
-        Cmd,
-        TrySend,
-    },
+    worker::{Cmd, TrySend},
 };
 
 impl<T: ToSocketAddrs> Builder<T, UdpSocket> {
@@ -182,10 +165,7 @@ define_worker!(UdpSocket, SocketAddr);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::{
-        net::UdpSocket,
-        spawn,
-    };
+    use tokio::{net::UdpSocket, spawn};
 
     #[tokio::test]
     async fn from() -> MetricResult<()> {
@@ -211,7 +191,7 @@ mod tests {
     async fn emit() -> MetricResult<()> {
         pretty_env_logger::try_init().ok();
 
-        let mut server_socket = UdpSocket::bind("127.0.0.1:0").await?;
+        let server_socket = UdpSocket::bind("127.0.0.1:0").await?;
         let server_addr = server_socket.local_addr()?;
 
         debug!("server socket: {}", server_addr);
@@ -251,7 +231,7 @@ mod tests {
     async fn emit_multi() -> MetricResult<()> {
         pretty_env_logger::try_init().ok();
 
-        let mut server_socket = UdpSocket::bind("127.0.0.1:0").await?;
+        let server_socket = UdpSocket::bind("127.0.0.1:0").await?;
         let server_addr = server_socket.local_addr()?;
 
         debug!("server socket: {}", server_addr);

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,37 +1,25 @@
 //! Asynchronous Metric Sink implementation that uses Unix Datagram sockets.
 
-use cadence::{
-    MetricResult,
-    MetricSink,
-};
+use cadence::{MetricResult, MetricSink};
 
 use log::*;
 use std::{
     future::Future,
     io::Result,
-    panic::{
-        RefUnwindSafe,
-        UnwindSafe,
-    },
+    panic::{RefUnwindSafe, UnwindSafe},
     path::Path,
     pin::Pin,
 };
 
 use tokio::{
     net::UnixDatagram,
-    sync::mpsc::{
-        channel,
-        Sender,
-    },
+    sync::mpsc::{channel, Sender},
 };
 
 use crate::{
     builder::Builder,
     define_worker,
-    worker::{
-        Cmd,
-        TrySend,
-    },
+    worker::{Cmd, TrySend},
 };
 
 impl<T: AsRef<Path> + Send + Sync + Unpin + 'static> Builder<T, UnixDatagram> {
@@ -158,14 +146,8 @@ define_worker!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        env::temp_dir,
-        time::UNIX_EPOCH,
-    };
-    use tokio::{
-        net::UnixDatagram,
-        spawn,
-    };
+    use std::{env::temp_dir, time::UNIX_EPOCH};
+    use tokio::{net::UnixDatagram, spawn};
 
     #[tokio::test]
     async fn from() -> MetricResult<()> {
@@ -189,7 +171,7 @@ mod tests {
             "test_emit-{}.sock",
             UNIX_EPOCH.elapsed().unwrap_or_default().as_millis()
         ));
-        let mut server_socket = UnixDatagram::bind(&path)?;
+        let server_socket = UnixDatagram::bind(&path)?;
 
         let socket = UnixDatagram::unbound()?;
 
@@ -227,7 +209,7 @@ mod tests {
             "test_emit_multi-{}.sock",
             UNIX_EPOCH.elapsed().unwrap_or_default().as_millis()
         ));
-        let mut server_socket = UnixDatagram::bind(&path)?;
+        let server_socket = UnixDatagram::bind(&path)?;
 
         let socket = UnixDatagram::unbound()?;
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,21 +1,10 @@
 use std::{
-    io::{
-        Error,
-        ErrorKind,
-        Result,
-    },
-    panic::{
-        catch_unwind,
-        RefUnwindSafe,
-        UnwindSafe,
-    },
+    io::{Error, ErrorKind, Result},
+    panic::{catch_unwind, RefUnwindSafe, UnwindSafe},
     process::abort,
 };
 
-use tokio::sync::mpsc::{
-    error::TrySendError,
-    Sender,
-};
+use tokio::sync::mpsc::{error::TrySendError, Sender};
 
 #[derive(Clone, Debug)]
 pub enum Cmd {
@@ -29,7 +18,7 @@ pub trait TrySend: UnwindSafe + RefUnwindSafe {
     fn try_send(&self, cmd: Cmd) -> Result<()> {
         // self.tx is !RefUnwindSafe -- don't let it panic!
         let wrapped = catch_unwind(|| {
-            let mut tx = self.sender().clone();
+            let tx = self.sender().clone();
             tx.try_send(cmd)
         });
 
@@ -89,10 +78,7 @@ macro_rules! define_worker {
             max_delay: ::tokio::time::Duration,
         ) {
             use ::log::*;
-            use ::tokio::time::{
-                timeout_at,
-                Instant,
-            };
+            use ::tokio::time::{timeout_at, Instant};
 
             use $crate::worker::Cmd;
 
@@ -164,19 +150,12 @@ macro_rules! define_worker {
 mod tests {
     use super::*;
     use std::{
-        io::{
-            Error,
-            ErrorKind,
-            Result,
-        },
+        io::{Error, ErrorKind, Result},
         sync::Arc,
     };
 
     use tokio::{
-        sync::{
-            mpsc,
-            Mutex,
-        },
+        sync::{mpsc, Mutex},
         time::Duration,
     };
 
@@ -200,7 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_single_item() {
-        let (mut tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(1);
         let items = Arc::new(Mutex::new(Vec::default()));
         let socket = TestSocket {
             items: items.clone(),
@@ -224,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_multi_item() {
-        let (mut tx, rx) = mpsc::channel(2);
+        let (tx, rx) = mpsc::channel(2);
         let items = Arc::new(Mutex::new(Vec::default()));
         let socket = TestSocket {
             items: items.clone(),
@@ -249,7 +228,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_full_buffer() {
-        let (mut tx, rx) = mpsc::channel(2);
+        let (tx, rx) = mpsc::channel(2);
         let items = Arc::new(Mutex::new(Vec::default()));
         let socket = TestSocket {
             items: items.clone(),
@@ -277,7 +256,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_over_buffer_capacity() {
-        let (mut tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(1);
         let items = Arc::new(Mutex::new(Vec::default()));
         let socket = TestSocket {
             items: items.clone(),


### PR DESCRIPTION
```
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running target/debug/deps/tokio_cadence-e68f19eae466ca26

running 11 tests
test worker::tests::handle_over_buffer_capacity ... ok
test worker::tests::handle_single_item ... ok
test worker::tests::handle_multi_item ... ok
test udp::tests::from ... ok
test udp::tests::from_bad_address ... ok
test worker::tests::handle_full_buffer ... ok
test unix::tests::from ... ok
test udp::tests::emit ... ok
test udp::tests::emit_multi ... ok
test unix::tests::emit_multi ... ok
test unix::tests::emit ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests tokio-cadence

running 2 tests
test src/udp.rs - udp::TokioBatchUdpMetricSink (line 62) ... ok
test src/unix.rs - unix::TokioBatchUnixMetricSink (line 57) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```