### PR TITLE
chore: updated dependencies to the latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ keywords = ["cadence", "statsd", "metrics", "async", "tokio"]
 edition = "2018"
 
 [dependencies]
-cadence = "0.24"
+cadence = "0.29"
 log = "0.4"
-tokio = { version = "1.1", features = ["net", "sync", "time"] }
+tokio = { version = "1", features = ["net", "sync", "time"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"
 
 [dev-dependencies.tokio]
-version = "1.1"
+version = "1"
 features = ["net", "sync", "time", "macros", "rt-multi-thread"]


### PR DESCRIPTION
Updated `cadence` and made `tokio` less restrictive.